### PR TITLE
add codeql baseline sample

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,3 +28,11 @@ jobs:
       uses: github/codeql-action/autobuild@v1
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
+    - name: Check CodeQL alerts
+      run: |
+        alert_count=$(gh api repos/${{ github.repository_owner }}/${{ github.repository }}/code-scanning/alerts?state=open&ref=${{ github.ref }} --paginate | jq '. | length')
+        baseline=10
+        if (( alert_count > baseline )); then
+          echo "Number of alerts ($alert_count) exceeded the baseline ($baseline)."
+          exit 1
+        fi

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,3 +36,5 @@ jobs:
           echo "Number of alerts ($alert_count) exceeded the baseline ($baseline)."
           exit 1
         fi
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
       uses: github/codeql-action/analyze@v1
     - name: Check CodeQL alerts
       run: |
-        alert_count=$(gh api "repos/${{ github.repository_owner }}/${{ github.repository }}/code-scanning/alerts?state=open&ref=${{ github.ref }}" --paginate | jq '. | length')
+        alert_count=$(gh api "repos/${{ github.repository }}/code-scanning/alerts?state=open&ref=${{ github.ref }}" --paginate | jq '. | length')
         baseline=10
         if (( alert_count > baseline )); then
           echo "Number of alerts ($alert_count) exceeded the baseline ($baseline)."

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
       uses: github/codeql-action/analyze@v1
     - name: Check CodeQL alerts
       run: |
-        alert_count=$(gh api repos/${{ github.repository_owner }}/${{ github.repository }}/code-scanning/alerts?state=open&ref=${{ github.ref }} --paginate | jq '. | length')
+        alert_count=$(gh api "repos/${{ github.repository_owner }}/${{ github.repository }}/code-scanning/alerts?state=open&ref=${{ github.ref }}" --paginate | jq '. | length')
         baseline=10
         if (( alert_count > baseline )); then
           echo "Number of alerts ($alert_count) exceeded the baseline ($baseline)."


### PR DESCRIPTION
# add codeql baseline sample

This pull request includes a significant change to the `.github/workflows/codeql-analysis.yml` file. The change introduces a new step in the `jobs:` section of the workflow that checks the number of CodeQL alerts. If the number of alerts exceeds a specified baseline, the job will fail.

Here is the main change:

* <a href="diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188R31-R38">`.github/workflows/codeql-analysis.yml`</a>: Added a new job step named "Check CodeQL alerts". This step calculates the number of open CodeQL alerts and compares it to a baseline value. If the number of alerts exceeds the baseline, the job will exit with a failure status.

https://github.com/vulna-felickz/juice-shop/blob/c0281baccee088e083711f005dbf6647d5f5fe48/.github/workflows/codeql-analysis.yml#L31-L40

Sample output: 
<img width="610" alt="image" src="https://github.com/vulna-felickz/juice-shop/assets/1760475/dfb8ed90-9b67-4c1f-a3cc-1e105843e6cd">
