### PR TITLE
Adds pr branch for sql injection audit query from GHSL community repo

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,7 +8,6 @@
 # We have attempted to detect the languages in your repository. Please check
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -71,7 +71,7 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
 
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        queries: security-extended
+        queries: security-extended, GitHubSecurityLab/CodeQL-Community-Packs/javascript/src/audit/CWE-089/SqlInjectionAudit.ql@js-audit-sqlinjection
 
     # If the analyze step fails for one of the languages you are analyzing with
     # "We were unable to automatically build your code", modify the matrix above


### PR DESCRIPTION
Added query targets SQL injection vulnerabilities in JavaScript code via `GitHubSecurityLab/CodeQL-Community-Packs/javascript/src/audit/CWE-089/SqlInjectionAudit.ql@js-audit-sqlinjection `
- see PR https://github.com/GitHubSecurityLab/CodeQL-Community-Packs/pull/50

https://github.com/vulna-felickz/juice-shop/blob/2e7e25c72a25738e2d17ef366b8bf36608840303/.github/workflows/codeql-analysis.yml#L64-L74


Example: 
![image](https://github.com/vulna-felickz/juice-shop/assets/1760475/a7148b63-f9c1-431f-9257-bae18d2d3ccf)
